### PR TITLE
Allow Rake v12

### DIFF
--- a/lib/yard/rake/yardoc_task.rb
+++ b/lib/yard/rake/yardoc_task.rb
@@ -66,7 +66,8 @@ module YARD
       # Defines the rake task
       # @return [void]
       def define
-        desc "Generate YARD Documentation" unless ::Rake.application.last_comment
+        predicate = ::Rake.application.respond_to?(:last_description) ? :last_description : :last_comment
+        desc "Generate YARD Documentation" unless ::Rake.application.public_send(predicate)
         task(name) do
           before.call if before.is_a?(Proc)
           yardoc = YARD::CLI::Yardoc.new


### PR DESCRIPTION
Rake v11 deprecated #last_comment in favor of #last_description, so this PR changes it to allow both. (I use the frameless branch for https://github.com/localytics/humidifier for parity with https://github.com/aws/aws-sdk-ruby).